### PR TITLE
fix(Picker): emit first change

### DIFF
--- a/src/components/picker/picker-column.ts
+++ b/src/components/picker/picker-column.ts
@@ -388,11 +388,7 @@ export class PickerColumnCmp {
     }
 
     if (emitChange) {
-      if (this.lastIndex === undefined) {
-        // have not set a last index yet
-        this.lastIndex = this.col.selectedIndex;
-
-      } else if (this.lastIndex !== this.col.selectedIndex) {
+      if (this.lastIndex !== this.col.selectedIndex) {
         // new selected index has changed from the last index
         // update the lastIndex and emit that it has changed
         this.lastIndex = this.col.selectedIndex;


### PR DESCRIPTION
#### Short description of what this resolves:
IonChange is not emitted, If the selected value of a picker column changes the first time.

Example: you have an ionic date picker, an a minValue for the current year. If you change the year, the months and days are not refreshed, because of that.

#### Changes proposed in this pull request:

Emit IonChange output also on the first change.

**Fixes**: https://github.com/ionic-team/ionic-v3/issues/80

The same as this PR at the ionic4 repo: https://github.com/ionic-team/ionic/pull/14447
