### PR TITLE
fix(content.scss): disable PropertySortOrder

### DIFF
--- a/src/components/content/content.scss
+++ b/src/components/content/content.scss
@@ -34,6 +34,7 @@ a {
   z-index: $z-index-scroll-content;
   display: block;
 
+  // scss-lint:disable PropertySortOrder
   overflow-x: hidden;
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
#### Short description of what this resolves:
If run `npm run test`, this error displayed.

```
[23:48:39] components/content/content.scss:37 [W] PropertySortOrder: Properties should be ordered position, z-index, display, -webkit-overflow-scrolling, will-change, contain, overflow-x, overflow-y
```

When fix properties ordered, and run test, error is this.

```
[23:49:47] components/content/content.scss:36 [W] PropertySortOrder: Properties should be ordered position, z-index, display, contain, overflow-x, overflow-y, -webkit-overflow-scrolling, will-change
```
So I add `// scss-lint:disable PropertySortOrder` in this line.

#### Changes proposed in this pull request:

- content.scss

**Fixes**: #
