### PR TITLE
fix(range): add detect changes at _updateTicks

### DIFF
--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -473,6 +473,7 @@ export class Range extends BaseInput<any> implements AfterContentInit, ControlVa
         });
       }
     }
+    this._cd.detectChanges();
   }
 
   /** @hidden */


### PR DESCRIPTION
#### Short description of what this resolves:

_Range_ component snap ticks are not visible when it is wrapped by an element with an `*ngIf` condition.

#### Changes proposed in this pull request:
- Add ChangeDetectorRef detectChanges at the internal function _updateTicks.

**Fixes**: #246 
