### PR TITLE
fix: a bug fix to the issue 233

### DIFF
--- a/src/navigation/test/url-serializer.spec.ts
+++ b/src/navigation/test/url-serializer.spec.ts
@@ -11,7 +11,7 @@ import {
   normalizeLinks,
   urlToNavGroupStrings,
   } from '../url-serializer';
-import { MockView1, MockView2, MockView3, mockApp, mockDeepLinkConfig, mockNavController, mockTab, mockTabs, noop } from '../../util/mock-providers';
+import { MockView1, MockView2, MockView3, MockView4, MockView5, MockView6, mockApp, mockDeepLinkConfig, mockNavController, mockTab, mockTabs, noop } from '../../util/mock-providers';
 
 
 describe('UrlSerializer', () => {
@@ -727,6 +727,41 @@ describe('UrlSerializer', () => {
       expect(segmentPairs[0].segments[2].name).toEqual('viewthree');
       expect(segmentPairs[0].segments[2].data.itemId).toEqual('12345');
       expect(segmentPairs[0].segments[2].secondaryId).toEqual('tab-four');
+    });
+
+    it('should return a certain component if it\'s matched exactly even when we have param links that match too', () => {
+      const link1 = { component: MockView1, name: 'viewone', segment: 'account' };
+      const link2 = { component: MockView2, name: 'viewtwo', segment: 'account/addresses' };
+      const link3 = { component: MockView3, name: 'viewthree', segment: 'account/addresses/disabled' };
+      const link4 = { component: MockView4, name: 'viewfour', segment: ':userId/:categoryId/:productId' };
+      const link5 = { component: MockView5, name: 'viewfive', segment: ':userId/:categoryId' };
+      const link6 = { component: MockView6, name: 'viewsix', segment: ':userId' };
+
+      const links = normalizeLinks([link1, link2, link3, link4, link5, link6]);
+      const url1 = 'account';
+      const url2 = 'account/addresses';
+      const url3 = 'account/addresses/disabled';
+
+      const segmentPairs1 = convertUrlToDehydratedSegments(url1, links);
+      expect(segmentPairs1.length).toEqual(1);
+      expect(segmentPairs1[0].segments.length).toEqual(1);
+      expect(segmentPairs1[0].segments[0].id).toEqual('account');
+      expect(segmentPairs1[0].segments[0].name).toEqual('viewone');
+      expect(segmentPairs1[0].segments[0].component.name).toEqual(MockView1.name);
+
+      const segmentPairs2 = convertUrlToDehydratedSegments(url2, links);
+      expect(segmentPairs2.length).toEqual(1);
+      expect(segmentPairs2[0].segments.length).toEqual(1);
+      expect(segmentPairs2[0].segments[0].id).toEqual('account/addresses');
+      expect(segmentPairs2[0].segments[0].name).toEqual('viewtwo');
+      expect(segmentPairs2[0].segments[0].component.name).toEqual(MockView2.name);
+
+      const segmentPairs3 = convertUrlToDehydratedSegments(url3, links);
+      expect(segmentPairs3.length).toEqual(1);
+      expect(segmentPairs3[0].segments.length).toEqual(1);
+      expect(segmentPairs3[0].segments[0].id).toEqual('account/addresses/disabled');
+      expect(segmentPairs3[0].segments[0].name).toEqual('viewthree');
+      expect(segmentPairs3[0].segments[0].component.name).toEqual(MockView3.name);
     });
 
     it('should return a segment w/ secondary id even if it has the same name as a router link basic', () => {

--- a/src/navigation/url-serializer.ts
+++ b/src/navigation/url-serializer.ts
@@ -424,52 +424,59 @@ export function getSegmentsFromNavGroups(navGroups: NavGroup[], navLinks: NavLin
 
     const segmentPieces = navGroup.segmentPieces.concat([]);
 
-    for (let i = segmentPieces.length; i >= 0; i--) {
-      let created = false;
-      for (let j = 0; j < i; j++) {
-        const startIndex = i - j - 1;
-        const endIndex = i;
-        const subsetOfUrl = segmentPieces.slice(startIndex, endIndex);
-        for (const navLink of navLinks) {
-          if (!usedNavLinks.has(navLink.name)) {
-            const segment = getSegmentsFromUrlPieces(subsetOfUrl, navLink);
+    const matchedExactLink = navLinks.find(navLink => {
+      return navLink.segmentParts.join('/') === segmentPieces.join('/');
+    });
 
-            if (segment) {
-              i = startIndex + 1;
-              usedNavLinks.add(navLink.name);
-              created = true;
-              // sweet, we found a segment
-              segments.push(segment);
-              // now we want to null out the url subsection in the segmentPieces
-              for (let k = startIndex; k < endIndex; k++) {
-                segmentPieces[k] = null;
+    if (matchedExactLink) {
+      const segment = getSegmentsFromUrlPieces(segmentPieces, matchedExactLink);
+      segments.push(segment);
+    } else {
+      for (let i = segmentPieces.length; i >= 0; i--) {
+        let created = false;
+        for (let j = 0; j < i; j++) {
+          const startIndex = i - j - 1;
+          const endIndex = i;
+          const subsetOfUrl = segmentPieces.slice(startIndex, endIndex);
+          for (const navLink of navLinks) {
+            if (!usedNavLinks.has(navLink.name)) {
+              const segment = getSegmentsFromUrlPieces(subsetOfUrl, navLink);
+
+              if (segment) {
+                i = startIndex + 1;
+                usedNavLinks.add(navLink.name);
+                created = true;
+                // sweet, we found a segment
+                segments.push(segment);
+                // now we want to null out the url subsection in the segmentPieces
+                for (let k = startIndex; k < endIndex; k++) {
+                  segmentPieces[k] = null;
+                }
+                break;
               }
-              break;
             }
           }
+          if (created) {
+            break;
+          }
         }
-        if (created) {
-          break;
+        if (!created && segmentPieces[i - 1]) {
+          // this is very likely a tab's secondary identifier
+          segments.push({
+            id: null,
+            name: null,
+            secondaryId: segmentPieces[i - 1],
+            component: null,
+            loadChildren: null,
+            data: null,
+            defaultHistory: null
+          });
         }
-      }
-      if (!created && segmentPieces[i - 1]) {
-        // this is very likely a tab's secondary identifier
-        segments.push({
-          id: null,
-          name: null,
-          secondaryId: segmentPieces[i - 1],
-          component: null,
-          loadChildren: null,
-          data: null,
-          defaultHistory: null
-        });
       }
     }
-
     // since we're getting segments in from right-to-left in the url, reverse them
     // so they're in the correct order. Also filter out and bogus segments
     const orderedSegments = segments.reverse();
-
 
     // okay, this is the lazy persons approach here.
     // so here's the deal! Right now if section of the url is not a part of a segment
@@ -496,6 +503,8 @@ export function getSegmentsFromNavGroups(navGroups: NavGroup[], navLinks: NavLin
       segments: cleanedSegments
     });
   }
+
+
   return pairs;
 }
 
@@ -505,10 +514,10 @@ export function getSegmentsFromUrlPieces(urlSections: string[], navLink: NavLink
   }
   for (let i = 0; i < urlSections.length; i++) {
     if (!isPartMatch(urlSections[i], navLink.segmentParts[i])) {
-      // just return an empty array if the part doesn't match
       return null;
     }
   }
+  // just return an empty array if the part doesn't match
   return {
     id: urlSections.join('/'),
     name: navLink.name,

--- a/src/util/mock-providers.ts
+++ b/src/util/mock-providers.ts
@@ -556,7 +556,8 @@ export function mockDeepLinkConfig(links?: any[]): DeepLinkConfig {
       { component: MockView2, name: 'viewtwo' },
       { component: MockView3, name: 'viewthree' },
       { component: MockView4, name: 'viewfour' },
-      { component: MockView5, name: 'viewfive' }
+      { component: MockView5, name: 'viewfive' },
+      { component: MockView6, name: 'viewsix' }
     ]
   };
 }
@@ -572,6 +573,7 @@ export class MockView2 {}
 export class MockView3 {}
 export class MockView4 {}
 export class MockView5 {}
+export class MockView6 {}
 
 export function noop(): any { return 'noop'; }
 


### PR DESCRIPTION
#### Short description of what this resolves:
When there's a navLink with the url that matches strictly it should have priority in urlSerializer's function getSegmentsFromNavGroups() . Added that.

#### Changes proposed in this pull request:

- in getSegmentsFromNavGroups function we check now if url matches exactly some nav link url, if so we omit further looping to get matched navLink and give the matched link straight away.

**Fixes**: #233 
