### PR TITLE
924 issue fix

### DIFF
--- a/src/navigation/test/url-serializer.spec.ts
+++ b/src/navigation/test/url-serializer.spec.ts
@@ -11,7 +11,7 @@ import {
   normalizeLinks,
   urlToNavGroupStrings,
   } from '../url-serializer';
-import { MockView1, MockView2, MockView3, mockApp, mockDeepLinkConfig, mockNavController, mockTab, mockTabs, noop } from '../../util/mock-providers';
+import { MockView1, MockView2, MockView3, MockView4, MockView5, MockView6, mockApp, mockDeepLinkConfig, mockNavController, mockTab, mockTabs, noop } from '../../util/mock-providers';
 
 
 describe('UrlSerializer', () => {
@@ -727,6 +727,41 @@ describe('UrlSerializer', () => {
       expect(segmentPairs[0].segments[2].name).toEqual('viewthree');
       expect(segmentPairs[0].segments[2].data.itemId).toEqual('12345');
       expect(segmentPairs[0].segments[2].secondaryId).toEqual('tab-four');
+    });
+
+    it('should return a certain component if it\'s matched exactly even when we have param links that match too', () => {
+      const link1 = { component: MockView1, name: 'viewone', segment: 'account' };
+      const link2 = { component: MockView2, name: 'viewtwo', segment: 'account/addresses' };
+      const link3 = { component: MockView3, name: 'viewthree', segment: 'account/addresses/disabled' };
+      const link4 = { component: MockView4, name: 'viewfour', segment: ':userId/:categoryId/:productId' };
+      const link5 = { component: MockView5, name: 'viewfive', segment: ':userId/:categoryId' };
+      const link6 = { component: MockView6, name: 'viewsix', segment: ':userId' };
+
+      const links = normalizeLinks([link1, link2, link3, link4, link5, link6]);
+      const url1 = 'account';
+      const url2 = 'account/addresses';
+      const url3 = 'account/addresses/disabled';
+
+      const segmentPairs1 = convertUrlToDehydratedSegments(url1, links);
+      expect(segmentPairs1.length).toEqual(1);
+      expect(segmentPairs1[0].segments.length).toEqual(1);
+      expect(segmentPairs1[0].segments[0].id).toEqual('account');
+      expect(segmentPairs1[0].segments[0].name).toEqual('viewone');
+      expect(segmentPairs1[0].segments[0].component.name).toEqual(MockView1.name);
+
+      const segmentPairs2 = convertUrlToDehydratedSegments(url2, links);
+      expect(segmentPairs2.length).toEqual(1);
+      expect(segmentPairs2[0].segments.length).toEqual(1);
+      expect(segmentPairs2[0].segments[0].id).toEqual('account/addresses');
+      expect(segmentPairs2[0].segments[0].name).toEqual('viewtwo');
+      expect(segmentPairs2[0].segments[0].component.name).toEqual(MockView2.name);
+
+      const segmentPairs3 = convertUrlToDehydratedSegments(url3, links);
+      expect(segmentPairs3.length).toEqual(1);
+      expect(segmentPairs3[0].segments.length).toEqual(1);
+      expect(segmentPairs3[0].segments[0].id).toEqual('account/addresses/disabled');
+      expect(segmentPairs3[0].segments[0].name).toEqual('viewthree');
+      expect(segmentPairs3[0].segments[0].component.name).toEqual(MockView3.name);
     });
 
     it('should return a segment w/ secondary id even if it has the same name as a router link basic', () => {

--- a/src/navigation/test/url-serializer.spec.ts
+++ b/src/navigation/test/url-serializer.spec.ts
@@ -10,8 +10,21 @@ import {
   navGroupStringtoObjects,
   normalizeLinks,
   urlToNavGroupStrings,
-  } from '../url-serializer';
-import { MockView1, MockView2, MockView3, MockView4, MockView5, MockView6, mockApp, mockDeepLinkConfig, mockNavController, mockTab, mockTabs, noop } from '../../util/mock-providers';
+} from '../url-serializer';
+import {
+  MockView1,
+  MockView2,
+  MockView3,
+  MockView4,
+  MockView5,
+  MockView6,
+  mockApp,
+  mockDeepLinkConfig,
+  mockNavController,
+  mockTab,
+  mockTabs,
+  noop
+} from '../../util/mock-providers';
 
 
 describe('UrlSerializer', () => {
@@ -729,6 +742,75 @@ describe('UrlSerializer', () => {
       expect(segmentPairs[0].segments[2].secondaryId).toEqual('tab-four');
     });
 
+    it('should return a certain component if it matches more surely than a wildcard link', () => {
+      const link1 = { component: MockView1, name: 'viewone', segment: ':userId/linking/:productId' };
+      const link2 = { component: MockView2, name: 'viewtwo', segment: 'linking/:productId' };
+      const link3 = { component: MockView3, name: 'viewthree', segment: ':userId/thinking' };
+      const link4 = { component: MockView4, name: 'viewfour', segment: ':userId/:categoryId/:productId' };
+      const link5 = { component: MockView5, name: 'viewfive', segment: ':userId/:categoryId' };
+      const link6 = { component: MockView6, name: 'viewsix', segment: ':userId' };
+
+      const links = normalizeLinks([link1, link2, link3, link4, link5, link6]);
+      const url1 = '5/linking/6';
+      const url2 = 'linking/7';
+      const url3 = '8/thinking';
+      const url4 = 'hey/smth/smthelse';
+      const url5 = 'hi/smth2';
+      const url6 = 'hei';
+
+      const segmentPairs1 = convertUrlToDehydratedSegments(url1, links);
+      expect(segmentPairs1.length).toEqual(1);
+      expect(segmentPairs1[0].segments.length).toEqual(1);
+      expect(segmentPairs1[0].segments[0].id).toEqual('5/linking/6');
+      expect(segmentPairs1[0].segments[0].name).toEqual('viewone');
+      expect(segmentPairs1[0].segments[0].data.userId).toEqual('5');
+      expect(segmentPairs1[0].segments[0].data.productId).toEqual('6');
+      expect(segmentPairs1[0].segments[0].component.name).toEqual(MockView1.name);
+
+      const segmentPairs2 = convertUrlToDehydratedSegments(url2, links);
+      expect(segmentPairs2.length).toEqual(1);
+      expect(segmentPairs2[0].segments.length).toEqual(1);
+      expect(segmentPairs2[0].segments[0].id).toEqual('linking/7');
+      expect(segmentPairs2[0].segments[0].data.productId).toEqual('7');
+      expect(segmentPairs2[0].segments[0].name).toEqual('viewtwo');
+      expect(segmentPairs2[0].segments[0].component.name).toEqual(MockView2.name);
+
+      const segmentPairs3 = convertUrlToDehydratedSegments(url3, links);
+      expect(segmentPairs3.length).toEqual(1);
+      expect(segmentPairs3[0].segments.length).toEqual(1);
+      expect(segmentPairs3[0].segments[0].id).toEqual('8/thinking');
+      expect(segmentPairs3[0].segments[0].data.userId).toEqual('8');
+      expect(segmentPairs3[0].segments[0].name).toEqual('viewthree');
+      expect(segmentPairs3[0].segments[0].component.name).toEqual(MockView3.name);
+
+      const segmentPairs4 = convertUrlToDehydratedSegments(url4, links);
+      expect(segmentPairs4.length).toEqual(1);
+      expect(segmentPairs4[0].segments.length).toEqual(1);
+      expect(segmentPairs4[0].segments[0].id).toEqual('hey/smth/smthelse');
+      expect(segmentPairs4[0].segments[0].name).toEqual('viewfour');
+      expect(segmentPairs4[0].segments[0].data.userId).toEqual('hey');
+      expect(segmentPairs4[0].segments[0].data.categoryId).toEqual('smth');
+      expect(segmentPairs4[0].segments[0].data.productId).toEqual('smthelse');
+      expect(segmentPairs4[0].segments[0].component.name).toEqual(MockView4.name);
+
+      const segmentPairs5 = convertUrlToDehydratedSegments(url5, links);
+      expect(segmentPairs5.length).toEqual(1);
+      expect(segmentPairs5[0].segments.length).toEqual(1);
+      expect(segmentPairs5[0].segments[0].id).toEqual('hi/smth2');
+      expect(segmentPairs5[0].segments[0].name).toEqual('viewfive');
+      expect(segmentPairs5[0].segments[0].data.userId).toEqual('hi');
+      expect(segmentPairs5[0].segments[0].data.categoryId).toEqual('smth2');
+      expect(segmentPairs5[0].segments[0].component.name).toEqual(MockView5.name);
+
+      const segmentPairs6 = convertUrlToDehydratedSegments(url6, links);
+      expect(segmentPairs6.length).toEqual(1);
+      expect(segmentPairs6[0].segments.length).toEqual(1);
+      expect(segmentPairs6[0].segments[0].id).toEqual('hei');
+      expect(segmentPairs6[0].segments[0].name).toEqual('viewsix');
+      expect(segmentPairs6[0].segments[0].data.userId).toEqual('hei');
+      expect(segmentPairs6[0].segments[0].component.name).toEqual(MockView6.name);
+    });
+
     it('should return a certain component if it\'s matched exactly even when we have param links that match too', () => {
       const link1 = { component: MockView1, name: 'viewone', segment: 'account' };
       const link2 = { component: MockView2, name: 'viewtwo', segment: 'account/addresses' };
@@ -790,10 +872,10 @@ describe('UrlSerializer', () => {
 
       const links = normalizeLinks([link1, link2, link3, link4, link5]);
       const url = 'schedule/schedule/paramOne/hello/paramTwo/goodbye'
-                  + '/about/about/123'
-                  + '/tabs/t1/tab-one/third-page'
-                  + '/tabs/t2/tab-two/fourth-page/object/456'
-                  + '/fifth-page/taco-page';
+        + '/about/about/123'
+        + '/tabs/t1/tab-one/third-page'
+        + '/tabs/t2/tab-two/fourth-page/object/456'
+        + '/fifth-page/taco-page';
 
       const segmentPairs = convertUrlToDehydratedSegments(url, links);
       expect(segmentPairs.length).toEqual(3);

--- a/src/navigation/url-serializer.ts
+++ b/src/navigation/url-serializer.ts
@@ -424,52 +424,59 @@ export function getSegmentsFromNavGroups(navGroups: NavGroup[], navLinks: NavLin
 
     const segmentPieces = navGroup.segmentPieces.concat([]);
 
-    for (let i = segmentPieces.length; i >= 0; i--) {
-      let created = false;
-      for (let j = 0; j < i; j++) {
-        const startIndex = i - j - 1;
-        const endIndex = i;
-        const subsetOfUrl = segmentPieces.slice(startIndex, endIndex);
-        for (const navLink of navLinks) {
-          if (!usedNavLinks.has(navLink.name)) {
-            const segment = getSegmentsFromUrlPieces(subsetOfUrl, navLink);
+    const matchedExactLink = navLinks.find(navLink => {
+      return navLink.segmentParts.join('/') === segmentPieces.join('/');
+    });
 
-            if (segment) {
-              i = startIndex + 1;
-              usedNavLinks.add(navLink.name);
-              created = true;
-              // sweet, we found a segment
-              segments.push(segment);
-              // now we want to null out the url subsection in the segmentPieces
-              for (let k = startIndex; k < endIndex; k++) {
-                segmentPieces[k] = null;
+    if (matchedExactLink) {
+      const segment = getSegmentsFromUrlPieces(segmentPieces, matchedExactLink);
+      segments.push(segment);
+    } else {
+      for (let i = segmentPieces.length; i >= 0; i--) {
+        let created = false;
+        for (let j = 0; j < i; j++) {
+          const startIndex = i - j - 1;
+          const endIndex = i;
+          const subsetOfUrl = segmentPieces.slice(startIndex, endIndex);
+          for (const navLink of navLinks) {
+            if (!usedNavLinks.has(navLink.name)) {
+              const segment = getSegmentsFromUrlPieces(subsetOfUrl, navLink);
+
+              if (segment) {
+                i = startIndex + 1;
+                usedNavLinks.add(navLink.name);
+                created = true;
+                // sweet, we found a segment
+                segments.push(segment);
+                // now we want to null out the url subsection in the segmentPieces
+                for (let k = startIndex; k < endIndex; k++) {
+                  segmentPieces[k] = null;
+                }
+                break;
               }
-              break;
             }
           }
+          if (created) {
+            break;
+          }
         }
-        if (created) {
-          break;
+        if (!created && segmentPieces[i - 1]) {
+          // this is very likely a tab's secondary identifier
+          segments.push({
+            id: null,
+            name: null,
+            secondaryId: segmentPieces[i - 1],
+            component: null,
+            loadChildren: null,
+            data: null,
+            defaultHistory: null
+          });
         }
-      }
-      if (!created && segmentPieces[i - 1]) {
-        // this is very likely a tab's secondary identifier
-        segments.push({
-          id: null,
-          name: null,
-          secondaryId: segmentPieces[i - 1],
-          component: null,
-          loadChildren: null,
-          data: null,
-          defaultHistory: null
-        });
       }
     }
-
     // since we're getting segments in from right-to-left in the url, reverse them
     // so they're in the correct order. Also filter out and bogus segments
     const orderedSegments = segments.reverse();
-
 
     // okay, this is the lazy persons approach here.
     // so here's the deal! Right now if section of the url is not a part of a segment
@@ -496,6 +503,8 @@ export function getSegmentsFromNavGroups(navGroups: NavGroup[], navLinks: NavLin
       segments: cleanedSegments
     });
   }
+
+
   return pairs;
 }
 
@@ -505,10 +514,10 @@ export function getSegmentsFromUrlPieces(urlSections: string[], navLink: NavLink
   }
   for (let i = 0; i < urlSections.length; i++) {
     if (!isPartMatch(urlSections[i], navLink.segmentParts[i])) {
-      // just return an empty array if the part doesn't match
       return null;
     }
   }
+  // just return an empty array if the part doesn't match
   return {
     id: urlSections.join('/'),
     name: navLink.name,

--- a/src/navigation/url-serializer.ts
+++ b/src/navigation/url-serializer.ts
@@ -427,9 +427,33 @@ export function getSegmentsFromNavGroups(navGroups: NavGroup[], navLinks: NavLin
     const matchedExactLink = navLinks.find(navLink => {
       return navLink.segmentParts.join('/') === segmentPieces.join('/');
     });
+    const matchedMostLink = navLinks.map(navLink => {
+      if (navLink.segmentParts.length === segmentPieces.length) {
+        const matchedRateLinkObj =  {navLink, matchedExactlyPieces: 0};
+
+        for (let idx = 0; idx < navLink.segmentParts.length; idx++) {
+          const segmentPart = navLink.segmentParts[idx];
+          if (!segmentPart.startsWith(':')) {
+            if (segmentPart === segmentPieces[idx]) {
+              matchedRateLinkObj.matchedExactlyPieces++;
+            } else {
+              return null;
+            }
+          }
+        }
+
+        return matchedRateLinkObj;
+      }
+
+      return null;
+    }).filter(matchedLink => matchedLink).sort((l1, l2) => l2.matchedExactlyPieces - l1.matchedExactlyPieces)
+      .map(matchedRateLinkObj => matchedRateLinkObj.navLink)[0];
 
     if (matchedExactLink) {
       const segment = getSegmentsFromUrlPieces(segmentPieces, matchedExactLink);
+      segments.push(segment);
+    } else if (matchedMostLink) {
+      const segment = getSegmentsFromUrlPieces(segmentPieces, matchedMostLink);
       segments.push(segment);
     } else {
       for (let i = segmentPieces.length; i >= 0; i--) {

--- a/src/util/mock-providers.ts
+++ b/src/util/mock-providers.ts
@@ -556,7 +556,8 @@ export function mockDeepLinkConfig(links?: any[]): DeepLinkConfig {
       { component: MockView2, name: 'viewtwo' },
       { component: MockView3, name: 'viewthree' },
       { component: MockView4, name: 'viewfour' },
-      { component: MockView5, name: 'viewfive' }
+      { component: MockView5, name: 'viewfive' },
+      { component: MockView6, name: 'viewsix' }
     ]
   };
 }
@@ -572,6 +573,7 @@ export class MockView2 {}
 export class MockView3 {}
 export class MockView4 {}
 export class MockView5 {}
+export class MockView6 {}
 
 export function noop(): any { return 'noop'; }
 


### PR DESCRIPTION
#### Short description of what this resolves:
segment: ':userId/linking/:productId' // Fix segments with two params
segment: 'linking/:productId' // Fix segments with one param
segment: ':userId/thinking' // whitelist fallback
segment: ':a/' // whitelist fallback
segment: ':a/:b' // whitelist fallback
segment: ':a/:b/:c' // whitelist fallback
handles such routes.

with the url:
localhost:8100/5/linking/6
will go to the first route and etc

#### Changes proposed in this pull request:

- added additional route matching to choose most convenient route before fallbacking to white-list rules

**Fixes**: https://github.com/ionic-team/ionic-v3/issues/924
