### PR TITLE
fix(PickerComponent): correct usage of _colChange

### DIFF
--- a/src/components/picker/picker-component.ts
+++ b/src/components/picker/picker-component.ts
@@ -28,7 +28,7 @@ import { PickerColumnCmp } from './picker-column';
       </div>
       <div class="picker-columns">
         <div class="picker-above-highlight"></div>
-        <div *ngFor="let c of d.columns" [col]="c" class="picker-col" (ionChange)="_colChange($event)"></div>
+        <div *ngFor="let c of d.columns" [col]="c" class="picker-col" (ionChange)="_colChange()"></div>
         <div class="picker-below-highlight"></div>
       </div>
     </div>


### PR DESCRIPTION
Do not pass $event as parameter since _colChange does not except arguments

#### Short description of what this resolves:
_colChange function does not accept any arguments, but it is called with `$event` in the template.

#### Changes proposed in this pull request:

- do not call _colChange with `$event` as argument

**Fixes**: #
This is one issue if you run angular template checks.
e.g. if you run `ngc` with 
```
"angularCompilerOptions": {
  "fullTemplateTypeCheck": true
}
```

in your `tsconfig.json`