### PR TITLE
fix(Input): correct call of clearTextInput

### DIFF
--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -127,8 +127,8 @@ import { Platform } from '../../platform/platform';
 
   '<button ion-button *ngIf="_clearInput" clear class="text-input-clear-icon" ' +
     'type="button" ' +
-    '(click)="clearTextInput($event)" ' +
-    '(mousedown)="clearTextInput($event)" ' +
+    '(click)="clearTextInput()" ' +
+    '(mousedown)="clearTextInput()" ' +
     'tabindex="-1"></button>' +
 
   '<div class="input-cover" *ngIf="_useAssist" ' +


### PR DESCRIPTION
Do not pass $event to clearTextInput method since it does not accept arguments.

#### Short description of what this resolves:
clearTextInput function does not accept any arguments, but it is called with `$event` in the template.

#### Changes proposed in this pull request:

- do not call clearTextInput with `$event` as argument

**Fixes**: 
This is one issue if you run angular template checks.
e.g. if you run `ngc` with 
```
"angularCompilerOptions": {
  "fullTemplateTypeCheck": true
}
```
in your `tsconfig.json`
