### PR TITLE
fix(AlertComponent): check if d.buttons and d.inputs is defined

### DIFF
--- a/src/components/alert/alert-component.ts
+++ b/src/components/alert/alert-component.ts
@@ -25,7 +25,7 @@ import { AlertButton, AlertInputOptions, AlertOptions } from './alert-options';
         '<h3 id="{{subHdrId}}" class="alert-sub-title" *ngIf="d.subTitle" [innerHTML]="d.subTitle"></h3>' +
       '</div>' +
       '<div id="{{msgId}}" class="alert-message" [innerHTML]="d.message"></div>' +
-      '<div *ngIf="d.inputs.length" [ngSwitch]="inputType">' +
+      '<div *ngIf="d.inputs && d.inputs.length" [ngSwitch]="inputType">' +
 
         '<ng-template ngSwitchCase="radio">' +
           '<div class="alert-radio-group" role="radiogroup" [attr.aria-labelledby]="hdrId" [attr.aria-activedescendant]="activeId">' +
@@ -58,7 +58,7 @@ import { AlertButton, AlertInputOptions, AlertOptions } from './alert-options';
         '</ng-template>' +
 
       '</div>' +
-      '<div class="alert-button-group" [ngClass]="{\'alert-button-group-vertical\':d.buttons.length>2}">' +
+      '<div *ngIf="d.buttons && d.buttons.length" class="alert-button-group" [ngClass]="{\'alert-button-group-vertical\': d.buttons.length > 2}">' +
         '<button ion-button="alert-button" *ngFor="let b of d.buttons" (click)="btnClick(b)" [ngClass]="b.cssClass">' +
           '{{b.text}}' +
         '</button>' +
@@ -134,14 +134,14 @@ export class AlertCmp {
     // normalize the data
     const data = this.d;
 
-    data.buttons = data.buttons.map(button => {
+    data.buttons = data.buttons ? data.buttons.map(button => {
       if (typeof button === 'string') {
         return { text: button };
       }
       return button;
-    });
+    }) : [];
 
-    data.inputs = data.inputs.map((input, index) => {
+    data.inputs = data.inputs ? data.inputs.map((input, index) => {
       let r: AlertInputOptions = {
         type: input.type || 'text',
         name: isPresent(input.name) ? input.name : index + '',
@@ -156,7 +156,7 @@ export class AlertCmp {
         max: isPresent(input.max) ? input.max : null
       };
       return r;
-    });
+    }) : [];
 
 
     // An alert can be created with several different inputs. Radios,


### PR DESCRIPTION
Make sure buttons and inputs are defined. At least as empty array.
Only add them to the template, if they are defined and habe at least one entry.

#### Short description of what this resolves:
the definition of `d.buttons` and `d.inputs` is not safe inside of the alert component.

#### Changes proposed in this pull request:

- make sure d.buttons and d.inputs get correct defined in `ionViewDidLoad`
- check if they are defined and contain at least one item to be added to the template

**Fixes**: 
This is one issue if you run angular template checks.
e.g. if you run `ngc` with 
```
"angularCompilerOptions": {
  "fullTemplateTypeCheck": true
}
```
in your `tsconfig.json`

Errors:
```
node_modules/ionic-angular/components/alert/alert-component.d.ts.AlertCmp.html(1,417): : Object is possibly 'undefined'.
node_modules/ionic-angular/components/alert/alert-component.d.ts.AlertCmp.html(1,1760): : Object is possibly 'undefined'.
```
