### PR TITLE
fix(toggle): Add display: block to toggle element

### DIFF
--- a/scripts/snapshot/ionic.snapshot.js
+++ b/scripts/snapshot/ionic.snapshot.js
@@ -32,13 +32,10 @@ var IonicSnapshot = function(options) {
 
     self.flow = protractor.promise.controlFlow();
 
-    if(self.width > 0 && self.height > 0) {
-      self.flow.execute(function(){
-        return browser.driver.manage().window().setSize(self.width, self.height);
-      });
-    }
-    self.flow.execute(function(){
-      return browser.getCapabilities().then(function (capabilities) {
+    self.flow.execute(async () => {
+      try {
+        const capabilities = await browser.getCapabilities();
+        
         self.testData = {
           group_id: self.groupId,
           app_id: self.appId,
@@ -53,7 +50,18 @@ var IonicSnapshot = function(options) {
           version: capabilities.get('version'),
           access_key: options.accessKey
         };
-      });
+        
+        if (self.width > 0 && self.height > 0) {
+          const windowPadding = await browser.executeScript('return { w: window.outerWidth - window.innerWidth, h: window.outerHeight - window.innerHeight };');
+          
+          self.width += windowPadding.w;
+          self.height += windowPadding.h;
+          
+          browser.driver.manage().window().setSize(self.width, self.height);
+        }
+      } catch(err) {
+        throw err;
+      }
     });
 
     process.on('exit', function(code) {

--- a/src/components/toggle/toggle.ios.scss
+++ b/src/components/toggle/toggle.ios.scss
@@ -83,7 +83,7 @@ $toggle-ios-item-end-padding-start:    $item-ios-padding-start !default;
 
 .toggle-ios {
   position: relative;
-  display: flex;
+  display: block;
 
   width: $toggle-ios-width;
   height: $toggle-ios-height;

--- a/src/components/toggle/toggle.ios.scss
+++ b/src/components/toggle/toggle.ios.scss
@@ -83,6 +83,7 @@ $toggle-ios-item-end-padding-start:    $item-ios-padding-start !default;
 
 .toggle-ios {
   position: relative;
+  display: flex;
 
   width: $toggle-ios-width;
   height: $toggle-ios-height;

--- a/src/components/toggle/toggle.md.scss
+++ b/src/components/toggle/toggle.md.scss
@@ -107,6 +107,7 @@ $toggle-md-item-end-padding-start:       $item-md-padding-start !default;
 
 .toggle-md {
   position: relative;
+  display: flex;
 
   width: $toggle-md-track-width;
   height: $toggle-md-track-height;

--- a/src/components/toggle/toggle.md.scss
+++ b/src/components/toggle/toggle.md.scss
@@ -107,7 +107,7 @@ $toggle-md-item-end-padding-start:       $item-md-padding-start !default;
 
 .toggle-md {
   position: relative;
-  display: flex;
+  display: block;
 
   width: $toggle-md-track-width;
   height: $toggle-md-track-height;

--- a/src/components/toggle/toggle.wp.scss
+++ b/src/components/toggle/toggle.wp.scss
@@ -95,6 +95,7 @@ $toggle-wp-item-end-padding-start:       $item-wp-padding-start !default;
 
 .toggle-wp {
   position: relative;
+  display: flex;
 
   width: $toggle-wp-track-width;
   height: $toggle-wp-track-height;

--- a/src/components/toggle/toggle.wp.scss
+++ b/src/components/toggle/toggle.wp.scss
@@ -95,7 +95,7 @@ $toggle-wp-item-end-padding-start:       $item-wp-padding-start !default;
 
 .toggle-wp {
   position: relative;
-  display: flex;
+  display: block;
 
   width: $toggle-wp-track-width;
   height: $toggle-wp-track-height;


### PR DESCRIPTION
#### Short description of what this resolves:

When using `ion-toggle` without `ion-item` there is a bug that prevents the dimensions of the track from being calculated properly.

#### Changes proposed in this pull request:

- Add `display: block` to the toggle element for each platform

**Fixes**: #
