### PR TITLE
chore(): update github repo name in release

### DIFF
--- a/scripts/gulp/tasks/release.ts
+++ b/scripts/gulp/tasks/release.ts
@@ -88,7 +88,7 @@ task('release.publishGithubRelease', (done: Function) => {
   .pipe(obj(function(file, enc, cb) {
     github.releases.createRelease({
       owner: 'ionic-team',
-      repo: 'ionic',
+      repo: 'ionic-v3',
       target_commitish: 'v3',
       tag_name: 'v' + packageJSON.version,
       name: packageJSON.version,


### PR DESCRIPTION
#### Short description of what this resolves:
Updates release scripts to use this repo

#### Changes proposed in this pull request:

- Change `ionic` to `ionic-v3` in the release scripts.
-
-

**Fixes**: #958
