### PR TITLE
fixed(virtual-scroll): validate nulls on scrollUpdate

### DIFF
--- a/src/components/virtual-scroll/virtual-scroll.ts
+++ b/src/components/virtual-scroll/virtual-scroll.ts
@@ -716,6 +716,11 @@ export class VirtualScroll implements DoCheck, OnChanges, AfterContentInit, OnDe
    * @hidden
    */
   scrollUpdate(ev: ScrollEvent) {
+    // ensure no empty are processed
+    if (!ev) {
+      return;
+    }
+
     // set the scroll top from the scroll event
     this._data.scrollTop = ev.scrollTop;
 


### PR DESCRIPTION
#### Short description of what this resolves:

When using scrollTo on a content with VirtualScroll there was a possibility that empty events would get emitted causing VirtualScroll to crash. 

#### Changes proposed in this pull request:

- Validate null ScrollEvents on scrollUpdate method in VirtualScroll

**Fixes**: #967
