### PR TITLE
Fixed nodes memory leak

### DIFF
--- a/src/navigation/view-controller.ts
+++ b/src/navigation/view-controller.ts
@@ -47,6 +47,7 @@ export class ViewController {
   _state: number = STATE_NEW;
   _cssClass: string;
   _ts: number;
+  _bindHandler: any;
 
   /**
    * Observable to be subscribed to when the current component will become active
@@ -113,7 +114,8 @@ export class ViewController {
 
     this._cssClass = rootCssClass;
     this._ts = Date.now();
-    window.addEventListener('orientationchange', this.handleOrientationChange.bind(this));
+    this._bindHandler = this.handleOrientationChange.bind(this);
+    window.addEventListener('orientationchange', this._bindHandler);
   }
 
   handleOrientationChange() {
@@ -542,7 +544,7 @@ export class ViewController {
         renderer.setElementAttribute(cmpEle, 'style', null);
       }
 
-      window.removeEventListener('orientationchange', this.handleOrientationChange.bind(this));
+      window.removeEventListener('orientationchange', this._bindHandler);
       // completely destroy this component. boom.
       this._cmp.destroy();
     }


### PR DESCRIPTION
#### Short description of what this resolves:
This fixes the detached elements linked to a view controller not being released by the garbage collector.
See https://github.com/ionic-team/ionic/issues/12574#issuecomment-368843850 for original fix.

My current work around is to by pass the 'orientationchange' event listerner registration in main.ts. Not perfect but does the job while this gets merged.

```
const originalAddEventListener = Window.prototype.addEventListener;
Window.prototype.addEventListener = function(type, handler) {
  if (type !== 'orientationchange') {
    originalAddEventListener(type, handler);
  }
};
```

#### Changes proposed in this pull request:

- Keeping a reference to the bind handler to remove it properly on destroy.

**Fixes**: #231
