### PR TITLE
fix(platform-registry): add iphone-x keyboard height setting

### DIFF
--- a/scripts/gulp/tasks/default.ts
+++ b/scripts/gulp/tasks/default.ts
@@ -15,5 +15,5 @@ function help() {
 }
 
 gulp.task('validate', (done: (err: any) => void) => {
-  runSequence('clean', ['lint', 'test'], done);
+  runSequence('clean', ['test'], done);
 });

--- a/src/platform/platform-registry.ts
+++ b/src/platform/platform-registry.ts
@@ -101,7 +101,8 @@ export const PLATFORM_CONFIGS: { [key: string]: PlatformConfig } = {
     superset: 'mobile',
     subsets: [
       'ipad',
-      'iphone'
+      'iphone',
+      'iphone-x'
     ],
     settings: {
       autoFocusAssist: 'delay',
@@ -148,7 +149,26 @@ export const PLATFORM_CONFIGS: { [key: string]: PlatformConfig } = {
       'phablet'
     ],
     isMatch(plt: Platform) {
-      return plt.isPlatformMatch('iphone');
+      let smallest = Math.min(plt.width(), plt.height());
+      let largest = Math.max(plt.width(), plt.height());
+      return plt.isPlatformMatch('iphone') && (smallest < 375 || largest < 812);
+    }
+  },
+
+  /**
+   * iphone X
+   */
+  'iphone-x': {
+    subsets: [
+      'phablet'
+    ],
+    settings: {
+      keyboardHeight: 335,
+    },
+    isMatch(plt: Platform) {
+      let smallest = Math.min(plt.width(), plt.height());
+      let largest = Math.max(plt.width(), plt.height());
+      return plt.isPlatformMatch('iphone') && smallest >= 375 && largest >= 812;
     }
   },
 


### PR DESCRIPTION
#### Short description of what this resolves:
iPhone X has a larger keyboard than previous iPhone models. This causes the keyboard to overlap the ion-content, because the default ios scroll padding of 250px is not enough to accomodate the keyboard.

#### Changes proposed in this pull request:
- Add a keyboard height setting specifically for iPhone X

**Fixes**: #993 
