### PR TITLE
fix(nav): add patch for iOS 12.2 scrolling bug

### DIFF
--- a/src/navigation/nav-controller-base.ts
+++ b/src/navigation/nav-controller-base.ts
@@ -763,6 +763,26 @@ export class NavControllerBase extends Ion implements NavController {
       }
 
       this._cleanup(enteringView);
+
+      /**
+       * On iOS 12.2 there is a bug that
+       * causes scrolling to not
+       * be re-enabled unless there
+       * is some kind of CSS reflow triggered
+       */
+      if (enteringView.getIONContentRef()) {
+        const platform = this.plt;
+        platform.timeout(() => {
+          platform.raf(() => {
+            const content = enteringView.getIONContentRef().nativeElement;
+            content.style.zIndex = '1';
+
+            platform.raf(() => {
+              content.style.zIndex = '';
+            });
+          });
+        }, 500);
+      }
     } else {
       // If transition does not complete, we have to cleanup anyway, because
       // previous pages in the stack are not hidden probably.


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes another iOS 12.2 bug where scrolling is disabled until a css reflow happens

#### Changes proposed in this pull request:

- Toggle z-index on entering view to cause a reflow
