### PR TITLE
fix(): add undefined and iOS checks when running iOS 12.2 scrolling patches

### DIFF
--- a/src/navigation/nav-controller-base.ts
+++ b/src/navigation/nav-controller-base.ts
@@ -772,8 +772,8 @@ export class NavControllerBase extends Ion implements NavController {
        */
       const platform = this.plt;
       if (
-        enteringView && 
-        enteringView.getIONContentRef && 
+        enteringView &&
+        enteringView.getIONContentRef &&
         enteringView.getIONContentRef() &&
         platform.is('ios')
       ) {

--- a/src/navigation/nav-controller-base.ts
+++ b/src/navigation/nav-controller-base.ts
@@ -770,8 +770,13 @@ export class NavControllerBase extends Ion implements NavController {
        * be re-enabled unless there
        * is some kind of CSS reflow triggered
        */
-      if (enteringView.getIONContentRef()) {
-        const platform = this.plt;
+      const platform = this.plt;
+      if (
+        enteringView && 
+        enteringView.getIONContentRef && 
+        enteringView.getIONContentRef() &&
+        platform.is('ios')
+      ) {
         platform.timeout(() => {
           platform.raf(() => {
             const content = enteringView.getIONContentRef().nativeElement;


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes an issue where an error was thrown via a modal

#### Changes proposed in this pull request:

- Add iOS check to only run fix on iOS
- Add undefined check to prevent undefined errors

