### PR TITLE
Removed deprecated DOCUMENT from @angular/platform-browser

### DIFF
--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -1,5 +1,6 @@
 import { EventEmitter, Injectable, Optional } from '@angular/core';
-import { DOCUMENT, Title } from '@angular/platform-browser';
+import { DOCUMENT } from '@angular/common';
+import { Title } from '@angular/platform-browser';
 
 import { IonicApp } from './app-root';
 import * as Constants from './app-constants';

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,7 +3,8 @@
  */
 import { ANALYZE_FOR_ENTRY_COMPONENTS, APP_INITIALIZER, ComponentFactoryResolver, Inject, Injector, ModuleWithProviders, NgModule, NgZone, Optional } from '@angular/core';
 import { APP_BASE_HREF, HashLocationStrategy, Location, LocationStrategy, PathLocationStrategy, PlatformLocation } from '@angular/common';
-import { DOCUMENT, HAMMER_GESTURE_CONFIG } from '@angular/platform-browser';
+import { DOCUMENT } from '@angular/common';
+import { HAMMER_GESTURE_CONFIG } from '@angular/platform-browser';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 


### PR DESCRIPTION
#### Short description of what this resolves:

DOCUMENT is removed from @angular/platform-browser If you use DOCUMENT from @angular/platform-browser, you should start to import this from @angular/common.

#### Changes proposed in this pull request:
Importing "Document" from @angular/common Instead of @angular/platform-browser

**Fixes**: #
IN "src\components\app\app.js"
Replace:
import { DOCUMENT, Title } from '@angular/platform-browser';
WITH:
import { DOCUMENT } from '@angular/common';
import { Title } from '@angular/platform-browser';

and IN "src\module.js"
Replace:
import { DOCUMENT, HAMMER_GESTURE_CONFIG } from '@angular/platform-browser';
With:
import { DOCUMENT } from '@angular/common';
import { HAMMER_GESTURE_CONFIG } from '@angular/platform-browser';