### PR TITLE
Fix: #1049

### DIFF
--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -611,7 +611,8 @@ export class TextInput extends BaseInput<string> implements IonicFormInput {
       // focus this input if the pointer hasn't moved XX pixels
       // and the input doesn't already have focus
       if (!hasPointerMoved(8, this._coord, endCoord) && !this.isFocus()) {
-        ev.preventDefault();
+        // ev.preventDefault(); // This breaks the first time tap behavior on Android 9.
+        // @see https://github.com/ionic-team/ionic-v3/issues/1049
         ev.stopPropagation();
 
         // begin the input focus process


### PR DESCRIPTION
Bugfix for Android Pi (9) <ion-input> first time tap not working.

#### Short description of what this resolves:
This resolves the issue, that on Android 9 the first tap without setting focus with user interaction will not let appear the keyboard.

#### Changes proposed in this pull request:

- Remove the preventDefault

**Fixes**: #1049
