### PR TITLE
WIP: fix(modal): improves modal a11y

### DIFF
--- a/src/components/modal/modal-component.ts
+++ b/src/components/modal/modal-component.ts
@@ -13,6 +13,11 @@ import { assert } from '../../util/util';
  */
 @Component({
   selector: 'ion-modal',
+  host: {
+    'role': 'dialog',
+    'tabindex': '-1',
+    'aria-dialog': ''
+  },
   template:
     '<ion-backdrop (click)="_bdClick()" [class.backdrop-no-tappable]="!_bdDismiss"></ion-backdrop>' +
     '<div class="modal-wrapper">' +
@@ -71,18 +76,13 @@ export class ModalCmp {
 
     this._setCssClass(componentRef, 'ion-page');
     this._setCssClass(componentRef, 'show-page');
-    this._setAttribute(componentRef, 'tabindex', '-1');
-    this._setAttribute(componentRef, 'aria-dialog', 'true');
-    this._setAttribute(componentRef, 'role', 'dialog');
-    setTimeout(() => {
-        componentRef.location.nativeElement.focus();
-    }, 200);
 
     // Change the viewcontroller's instance to point the user provided page
     // Lifecycle events will be sent to the new instance, instead of the modal's component
     // we need to manually subscribe to them
     this._viewCtrl._setInstance(componentRef.instance);
     this._viewCtrl.willEnter.subscribe(this._viewWillEnter.bind(this));
+    this._viewCtrl.didEnter.subscribe(this._viewDidEnter.bind(this));
     this._viewCtrl.didLeave.subscribe(this._viewDidLeave.bind(this));
 
     this._enabled = true;
@@ -92,16 +92,18 @@ export class ModalCmp {
     this._gestureBlocker.block();
   }
 
+  _viewDidEnter() {
+      setTimeout(() => {
+        this._elementRef.nativeElement.focus();
+      });
+  }
+
   _viewDidLeave() {
     this._gestureBlocker.unblock();
   }
 
   _setCssClass(componentRef: any, className: string) {
     this._renderer.setElementClass(componentRef.location.nativeElement, className, true);
-  }
-
-  _setAttribute(componentRef: any, attributeName: string, attributeValue: string) {
-      this._renderer.setElementAttribute(componentRef.location.nativeElement, attributeName, attributeValue);
   }
 
   _bdClick() {

--- a/src/components/modal/modal-component.ts
+++ b/src/components/modal/modal-component.ts
@@ -8,6 +8,9 @@ import { BlockerDelegate, GESTURE_GO_BACK_SWIPE, GESTURE_MENU_SWIPE,  GestureCon
 import { ModuleLoader } from '../../util/module-loader';
 import { assert } from '../../util/util';
 
+import { Subject } from 'rxjs/Subject';
+import 'rxjs/add/operator/take';
+
 /**
  * @hidden
  */
@@ -82,7 +85,7 @@ export class ModalCmp {
     // we need to manually subscribe to them
     this._viewCtrl._setInstance(componentRef.instance);
     this._viewCtrl.willEnter.subscribe(this._viewWillEnter.bind(this));
-    this._viewCtrl.didEnter.subscribe(this._viewDidEnter.bind(this));
+    this._viewCtrl.didEnter.take(1).subscribe(this._viewDidEnter.bind(this));
     this._viewCtrl.didLeave.subscribe(this._viewDidLeave.bind(this));
 
     this._enabled = true;
@@ -95,7 +98,7 @@ export class ModalCmp {
   _viewDidEnter() {
       setTimeout(() => {
         this._elementRef.nativeElement.focus();
-      });
+      }, 10);
   }
 
   _viewDidLeave() {

--- a/src/components/modal/modal-component.ts
+++ b/src/components/modal/modal-component.ts
@@ -71,6 +71,12 @@ export class ModalCmp {
 
     this._setCssClass(componentRef, 'ion-page');
     this._setCssClass(componentRef, 'show-page');
+    this._setAttribute(componentRef, 'tabindex', '-1');
+    this._setAttribute(componentRef, 'aria-dialog', 'true');
+    this._setAttribute(componentRef, 'role', 'dialog');
+    setTimeout(() => {
+        componentRef.location.nativeElement.focus();
+    }, 200);
 
     // Change the viewcontroller's instance to point the user provided page
     // Lifecycle events will be sent to the new instance, instead of the modal's component
@@ -92,6 +98,10 @@ export class ModalCmp {
 
   _setCssClass(componentRef: any, className: string) {
     this._renderer.setElementClass(componentRef.location.nativeElement, className, true);
+  }
+
+  _setAttribute(componentRef: any, attributeName: string, attributeValue: string) {
+      this._renderer.setElementAttribute(componentRef.location.nativeElement, attributeName, attributeValue);
   }
 
   _bdClick() {


### PR DESCRIPTION
Improves the modal a11y by correctly setting the tabindex, role, and aria-dialog attributes on the `ion-modal` element in addition to pushing focus to that element after it renders so that the dialog is announced properly.

Using https://github.com/dallastjames/ion-accessibility-v3 with `npm link` to test the modal on Android Talkback

The issue I'm seeing with this PR is how focus is being pulled to the dialog. It needs to happen otherwise Android Talkback wont announce the Dialog correctly. But, the setTimeout is gross, and I feel like forcing the focus to the modal could disrupt the user from setting the focus to a button or input. 